### PR TITLE
Add integration tests to GHA

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -19,9 +19,35 @@ jobs:
 
     name: PHP ${{ matrix.php }} tests
 
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_USERNAME: admin
+      DB_PASSWORD: adminpass
+      DB_DATABASE: test
+      DB_ROOT_USERNAME: root
+      DB_ROOT_PASSWORD: rootpass
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_DATABASE: ${{ env.DB_DATABASE }}
+          MYSQL_HOST: ${{ env.DB_HOST }}
+          MYSQL_USER: ${{ env.DB_USERNAME }}
+          MYSQL_PASSWORD: ${{ env.DB_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ env.DB_ROOT_PASSWORD }}
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set up MySQL
+        run: |
+          mysql -h${{ env.DB_HOST }} -P${{ env.DB_PORT }} -u${{ env.DB_ROOT_USERNAME }} -p${{ env.DB_ROOT_PASSWORD }} ${{ env.DB_DATABASE }} < schema/mysql.sql
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -43,6 +69,8 @@ jobs:
 
       - name: PHPUnit
         run: vendor/bin/phpunit --coverage-clover=coverage.xml
+        env:
+          INTEGRATION_ENABLED: 1
 
       - name: "Upload coverage to Codecov"
         uses: "codecov/codecov-action@v2"

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 vendor
 report
 composer.lock
-phpunit.xml

--- a/.runConfigurations/All tests.run.xml
+++ b/.runConfigurations/All tests.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All tests" type="PHPUnitRunConfigurationType" factoryName="PHPUnit">
+    <CommandLine>
+      <envs>
+        <env name="DB_DATABASE" value="test" />
+        <env name="DB_USERNAME" value="root" />
+        <env name="INTEGRATION_ENABLED" value="1" />
+      </envs>
+    </CommandLine>
+    <TestRunner configuration_file="$PROJECT_DIR$/phpunit.xml.dist" directory="$PROJECT_DIR$/tests" scope="XML" options="--verbose" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.runConfigurations/All unit tests.run.xml
+++ b/.runConfigurations/All unit tests.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All unit tests" type="PHPUnitRunConfigurationType" factoryName="PHPUnit">
+    <TestRunner configuration_file="$PROJECT_DIR$/phpunit.xml.dist" directory="$PROJECT_DIR$/tests" scope="XML" options="--verbose" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.runConfigurations/Integration tests.run.xml
+++ b/.runConfigurations/Integration tests.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Integration tests" type="PHPUnitRunConfigurationType" factoryName="PHPUnit">
+    <CommandLine>
+      <envs>
+        <env name="DB_DATABASE" value="test" />
+        <env name="DB_USERNAME" value="root" />
+        <env name="INTEGRATION_ENABLED" value="1" />
+      </envs>
+    </CommandLine>
+    <TestRunner configuration_file="$PROJECT_DIR$/phpunit.xml.dist" directory="$PROJECT_DIR$/tests" scope="XML" options="--verbose --group=integration" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit bootstrap="vendor/autoload.php" colors="true">
-
     <php>
-        <!--<var name="PDO_DSN" value="mysql:host=127.0.0.1;dbname=test" />-->
-        <!--<var name="PDO_USER" value="root" />-->
-        <!--<var name="PDO_PASS" value="" />-->
-        <!--<var name="PDO_DBNAME" value="FlysystemPdo" />-->
+        <env name="INTEGRATION_ENABLED" value="0" />
+        <env name="DB_HOST" value="127.0.0.1" />
+        <env name="DB_PORT" value="3306" />
+        <env name="DB_USERNAME" value="" />
+        <env name="DB_PASSWORD" value="" />
+        <env name="DB_DATABASE" value="test" />
     </php>
-
     <testsuites>
         <testsuite name="FlysystemPdo Test Suite">
             <directory>tests</directory>

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -49,14 +49,24 @@ class IntegrationTest extends \PHPUnit_Extensions_Database_TestCase
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
-        if (!isset($GLOBALS['PDO_DSN']) || !isset($GLOBALS['PDO_USER']) || !isset($GLOBALS['PDO_PASS']) || !isset($GLOBALS['PDO_DBNAME'])) {
-            // insufficient values to work with
+        if (!getenv('INTEGRATION_ENABLED')) {
+            // Integration test not enabled
             return;
         }
 
-        $dsn            = $GLOBALS['PDO_DSN'];
-        static::$driver = substr($dsn, 0, strpos($dsn, ':'));
-        static::$pdo    = new \PDO($dsn, $GLOBALS['PDO_USER'], $GLOBALS['PDO_PASS']);
+        // @todo allow tests to use alternative to MySQL
+        $dsn = 'mysql:host=' . getenv('DB_HOST') . ';port=' . getenv('DB_PORT') . ';dbname=' . getenv('DB_DATABASE');
+        static::$driver = 'mysql';
+        static::$pdo = new \PDO(
+            $dsn,
+            getenv('DB_USERNAME'),
+            getenv('DB_PASSWORD'),
+            [
+                \PDO::ATTR_TIMEOUT => 2,
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+            ]
+        );
 
         // create files
         $tmpDir             = sys_get_temp_dir() . DIRECTORY_SEPARATOR;
@@ -124,7 +134,7 @@ class IntegrationTest extends \PHPUnit_Extensions_Database_TestCase
      */
     public function getConnection()
     {
-        return $this->createDefaultDBConnection(static::$pdo, $GLOBALS['PDO_DBNAME']);
+        return $this->createDefaultDBConnection(static::$pdo, getenv('DB_DATABASE'));
     }
 
     /**


### PR DESCRIPTION
The tests show a failure on PHP v5.4, but fixing that is outside the scope of this branch, and support for PHP v5 is about to be removed anyway.