### PR TITLE
Fix issues shown by adding more coverage to integration tests

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           sudo /etc/init.d/mysql start
           mysql -e 'SHOW VARIABLES LIKE "version%";' -u${{ env.DB_USERNAME }} -p${{ env.DB_PASSWORD }}
+          mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u${{ env.DB_USERNAME }} -p${{ env.DB_PASSWORD }} mysql
           mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USERNAME }} -p${{ env.DB_PASSWORD }}
 
       - name: Set up PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Allow `rename()` to work on directories where no specific directory entry exists. 
 ### Changed
 - DB schema has been updated to include the optional `expiry` and `meta` columns.
 - DB schema character set has been updated to use `utf8mb4` instead of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- DB schema has been updated to include the optional `expiry` column.
+### Fixed
+- Type error when using `deleteExpired()`.
 
 ## [2.0.0] - 2022-08-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
-- DB schema has been updated to include the optional `expiry` column.
+- DB schema has been updated to include the optional `expiry` and `meta` columns.
+- DB schema character set has been updated to use `utf8mb4` instead of the
+  deprecated `utf8`.
 ### Fixed
 - Type error when using `deleteExpired()`.
+- Error in response data when writing a new file with additional metadata.
 
 ## [2.0.0] - 2022-08-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - DB schema has been updated to include the optional `expiry` and `meta` columns.
 - DB schema character set has been updated to use `utf8mb4` instead of the
   deprecated `utf8`.
+- DB schema for Sqlite updated to store current timestamp. Sqlite always runs as
+  UTC, so this is converted when retrieving the metadata.
 ### Fixed
 - Type error when using `deleteExpired()`.
 - Error in response data when writing a new file with additional metadata.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ $adapter = new PdoAdapter($pdo, $config);
 
 ## File Configuration
 
-The following file configurations were added in version 1.1. These configurations and associated schema changes are 
-optional.
+The following optional file configurations supplement the standard behaviour.
+The sample schemas include the columns, but they are optional and may be omitted.
 
 |Name|Type|Description|
 |----|----|-----------|
@@ -78,9 +78,6 @@ By specifying 'expiry' as a configuration parameter when writing or updating a f
 will store the value in a column called 'expiry'. When the information about the file is selected out, if the expiry
 exists and can be parsed by `strtotime`, then the expiry time will be evaluated. False is returned if the file doesn't
 exist or has expired.
-
-The schema for the expiry column can be anything that stores a value that will be evaluated by `strtotime`. Typically 
-this will be a `timestamp` column type.
 
 #### Example
 

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -1,19 +1,20 @@
 CREATE TABLE `flysystem_path` (
   `path_id` MEDIUMINT UNSIGNED NOT NULL AUTO_INCREMENT, -- 16,777,215
   `type` ENUM('dir', 'file') NOT NULL,
-  `path` VARCHAR(255) NOT NULL,
-  `mimetype` VARCHAR(255) CHARACTER SET ascii DEFAULT NULL,
+  `path` VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL,
+  `mimetype` VARCHAR(255) DEFAULT NULL,
   `visibility` VARCHAR(25) DEFAULT '',
   `size` INT UNSIGNED DEFAULT NULL, -- equivalent to storing 4G file
   `is_compressed` BOOL NOT NULL DEFAULT 1,
   `expiry` TIMESTAMP NULL DEFAULT NULL,
+  `meta` TEXT CHARACTER SET utf8mb4,
   `update_ts` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`path_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=ascii;
 
 CREATE TABLE `flysystem_chunk` (
   `path_id` MEDIUMINT UNSIGNED NOT NULL,
   `chunk_no` SMALLINT(5) UNSIGNED NOT NULL, -- assuming 1M chunk sizes, allows for 64G
   `content` MEDIUMBLOB NOT NULL, -- allows up to 16M of binary data
   PRIMARY KEY (`path_id`,`chunk_no`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=ascii;

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -6,6 +6,7 @@ CREATE TABLE `flysystem_path` (
   `visibility` VARCHAR(25) DEFAULT '',
   `size` INT UNSIGNED DEFAULT NULL, -- equivalent to storing 4G file
   `is_compressed` BOOL NOT NULL DEFAULT 1,
+  `expiry` TIMESTAMP NULL DEFAULT NULL,
   `update_ts` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`path_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/schema/sqlite.sql
+++ b/schema/sqlite.sql
@@ -8,7 +8,7 @@ CREATE TABLE flysystem_path (
   is_compressed INTEGER DEFAULT 1,
   expiry TEXT DEFAULT NULL,
   meta TEXT DEFAULT NULL,
-  update_ts TEXT NOT NULL DEFAULT 0,
+  update_ts TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (path_id)
 );
 

--- a/schema/sqlite.sql
+++ b/schema/sqlite.sql
@@ -6,6 +6,7 @@ CREATE TABLE flysystem_path (
   visibility TEXT,
   size INTEGER DEFAULT NULL,
   is_compressed INTEGER DEFAULT 1,
+  expiry TEXT DEFAULT NULL,
   update_ts TEXT NOT NULL DEFAULT 0,
   PRIMARY KEY (path_id)
 );

--- a/schema/sqlite.sql
+++ b/schema/sqlite.sql
@@ -7,6 +7,7 @@ CREATE TABLE flysystem_path (
   size INTEGER DEFAULT NULL,
   is_compressed INTEGER DEFAULT 1,
   expiry TEXT DEFAULT NULL,
+  meta TEXT DEFAULT NULL,
   update_ts TEXT NOT NULL DEFAULT 0,
   PRIMARY KEY (path_id)
 );

--- a/src/PdoAdapter.php
+++ b/src/PdoAdapter.php
@@ -98,7 +98,8 @@ class PdoAdapter implements AdapterInterface
         }
         $meta = null;
         if ($config->has('meta')) {
-            $meta = $data['meta'] = $config->get('meta');
+            $meta = $config->get('meta');
+            $data['meta'] = json_encode($meta);
         }
 
         $data['path_id'] = $this->insertPath(

--- a/src/PdoAdapter.php
+++ b/src/PdoAdapter.php
@@ -681,7 +681,7 @@ class PdoAdapter implements AdapterInterface
 
         $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
         foreach ($rows as $row) {
-            $this->deletePath($row['path_id']);
+            $this->deletePath((int)$row['path_id']);
         }
 
         return $stmt->rowCount();

--- a/src/PdoAdapter.php
+++ b/src/PdoAdapter.php
@@ -578,6 +578,9 @@ class PdoAdapter implements AdapterInterface
             'path' => $data['path'],
             'timestamp' => strtotime($data['update_ts']),
         ];
+        if ($this->db->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            $meta['timestamp'] = strtotime($data['update_ts'] . ' +00:00');
+        }
         if ($data['type'] === self::TYPE_FILE) {
             $meta['mimetype'] = $data['mimetype'];
             $meta['size'] = (int)$data['size'];

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -716,6 +716,44 @@ class IntegrationTest extends IntegrationTestCase
         static::assertSame(AdapterInterface::VISIBILITY_PRIVATE, $actual);
     }
 
+    public function testGetMetadata(): void
+    {
+        $path = '/path/to/file.txt';
+        $contents = file_get_contents(static::$tempFiles['10K']);
+        $timestamp = time();
+
+        $this->adapter->write($path, $contents, $this->emptyConfig);
+        $actual = $this->adapter->getMetadata($path);
+
+        $expected = [
+            'path_id' => 1,
+            'type' => 'file',
+            'path' => $path,
+            'timestamp' => $timestamp,
+            'mimetype' => 'text/plain',
+            'size' => strlen($contents),
+            'visibility' => AdapterInterface::VISIBILITY_PUBLIC,
+        ];
+        static::assertSame($expected, $actual);
+
+        // individual attributes
+        static::assertSame([
+            'size' => strlen($contents),
+        ], $this->adapter->getSize($path));
+
+        static::assertSame([
+            'mimetype' => 'text/plain',
+        ], $this->adapter->getMimetype($path));
+
+        static::assertSame([
+            'timestamp' => $timestamp,
+        ], $this->adapter->getTimestamp($path));
+
+        static::assertSame([
+            'visibility' => AdapterInterface::VISIBILITY_PUBLIC,
+        ], $this->adapter->getVisibility($path));
+    }
+
     public function testDeleteExpired(): void
     {
         $content = sha1(uniqid('Test content'));

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -139,6 +139,25 @@ class IntegrationTest extends IntegrationTestCase
         static::assertFalse($actual);
     }
 
+    public function testWrittenAndReadWithAdditional(): void
+    {
+        $path = '/path/to/file.txt';
+        $additional = [
+            uniqid('key1') => sha1(uniqid('value1')),
+            uniqid('key2') => sha1(uniqid('value2')),
+        ];
+        $config = new Config([
+            'meta' => $additional,
+        ]);
+
+        $content = sha1(uniqid('Test content'));
+
+        $this->adapter->write($path, $content, $config);
+        $actual = $this->adapter->read($path);
+
+        static::assertSame($additional, $actual['meta']);
+    }
+
     /**
      * @dataProvider updatedAndReadAreTheSameFileDataProvider
      */
@@ -307,6 +326,81 @@ class IntegrationTest extends IntegrationTestCase
         static::assertFalse($actual);
     }
 
+    public function testUpdateWhenAdditionalSet(): void
+    {
+        $path = '/path/to/file.txt';
+        $additional = [
+            uniqid('key1') => sha1(uniqid('value1')),
+            uniqid('key2') => sha1(uniqid('value2')),
+        ];
+        $config = new Config([
+            'meta' => $additional,
+        ]);
+
+        $content1 = sha1(uniqid('Test content 1'));
+        $content2 = sha1(uniqid('Test content 2'));
+
+        $this->adapter->write($path, $content1, $config);
+
+        $this->adapter->update($path, $content2, $this->emptyConfig);
+
+        $actual = $this->adapter->read($path);
+
+        static::assertSame($additional, $actual['meta']);
+    }
+
+    public function testUpdateWithAdditionalAdd(): void
+    {
+        $path = '/path/to/file.txt';
+        $content = sha1(uniqid('Test content'));
+
+        $this->adapter->write($path, $content, $this->emptyConfig);
+
+        $additional = [
+            uniqid('key1') => sha1(uniqid('value1')),
+            uniqid('key2') => sha1(uniqid('value2')),
+        ];
+        $config = new Config([
+            'meta' => $additional,
+        ]);
+
+        $this->adapter->update($path, $content, $config);
+
+        $actual = $this->adapter->read($path);
+
+        static::assertSame($additional, $actual['meta']);
+    }
+
+    public function testUpdateWithAdditionalChange(): void
+    {
+        $path = '/path/to/file.txt';
+        $content = sha1(uniqid('Test content'));
+
+        $additional1 = [
+            uniqid('key1') => sha1(uniqid('value1')),
+            uniqid('key2') => sha1(uniqid('value2')),
+        ];
+        $config1 = new Config([
+            'meta' => $additional1,
+        ]);
+
+        $this->adapter->write($path, $content, $config1);
+
+        $additional2 = [
+            uniqid('key1') => sha1(uniqid('value1')),
+            uniqid('key2') => sha1(uniqid('value2')),
+        ];
+        $config2 = new Config([
+            'meta' => $additional2,
+        ]);
+
+        $this->adapter->update($path, $content, $config2);
+
+        $actual = $this->adapter->read($path);
+
+        static::assertSame($additional2, $actual['meta']);
+    }
+
     public function testCopyingFile(): void
     {
         $path1 = '/first.txt';
@@ -446,6 +540,23 @@ class IntegrationTest extends IntegrationTestCase
             [[$dir1, $dir2, $file1], 3],
             [[$dir1, $dir2, $dir3, $file1, $file2, $file3], 6],
         ];
+    }
+
+    public function testCreateDirectoryWithAdditional(): void
+    {
+        $path = '/new/directory';
+        $additional = [
+            uniqid('key1') => sha1(uniqid('value1')),
+            uniqid('key2') => sha1(uniqid('value2')),
+        ];
+        $config = new Config([
+            'meta' => $additional,
+        ]);
+
+        $this->adapter->createDir($path, $config);
+        $actual = $this->adapter->read($path);
+
+        static::assertSame($additional, $actual['meta']);
     }
 
     public function testDeletingDirectoryClearsAllFiles(): void

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -465,6 +465,29 @@ class IntegrationTest extends IntegrationTestCase
         static::assertSame($origDataSet, $copyDataSet);
     }
 
+    public function testRenameFile(): void
+    {
+        $path1 = '/first.txt';
+        $path2 = '/second.txt';
+
+        $testContent = file_get_contents(static::$tempFiles['10B']);
+
+        $this->adapter->write($path1, $testContent, $this->emptyConfig);
+
+        // Check successfully written, first
+        $actualOld = $this->adapter->read($path1);
+        static::assertSame($testContent, $actualOld['contents']);
+
+        // Perform rename; check original path is now missing and new path is present
+        $this->adapter->rename($path1, $path2);
+
+        $actual1New = $this->adapter->read($path1);
+        $actual2New = $this->adapter->read($path2);
+
+        static::assertFalse($actual1New);
+        static::assertSame($testContent, $actual2New['contents']);
+    }
+
     /**
      * @dataProvider pathsDataProvider
      */

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -53,6 +53,11 @@ abstract class IntegrationTestCase extends TestCase
             foreach ($createSql as $sql) {
                 static::$testDbAdapter->query($sql);
             }
+
+            if (static::$driver === 'mysql') {
+                $timezone = date_default_timezone_get();
+                static::$testDbAdapter->query("SET time_zone = '{$timezone}'");
+            }
         }
 
         return static::$testDbAdapter;

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -133,8 +133,14 @@ abstract class IntegrationTestCase extends TestCase
 
         parent::setUp();
 
-        static::getTestDbAdapter()->query('DELETE FROM flysystem_path');
-        static::getTestDbAdapter()->query('DELETE FROM flysystem_chunk');
+        $db = static::getTestDbAdapter();
+        if (static::getDbDriverName() === 'sqlite') {
+            $db->query('DELETE FROM flysystem_path');
+            $db->query('DELETE FROM flysystem_chunk');
+        } else {
+            $db->query('TRUNCATE flysystem_path');
+            $db->query('TRUNCATE flysystem_chunk');
+        }
     }
 
     final protected static function assertRowCount(int $expectedCount, string $tableName, string $message = ''): void

--- a/tests/PdoAdapterTest.php
+++ b/tests/PdoAdapterTest.php
@@ -118,6 +118,39 @@ class PdoAdapterTest extends TestCase
         static::assertSame($expected, $meta);
     }
 
+    public function testWriteWithExpiry(): void
+    {
+        $this->setupBasicDbResponse();
+
+        $pathId = rand(1, 1000);
+
+        $this->pdo->expects(static::once())
+            ->method('lastInsertId')
+            ->willReturn((string)$pathId);
+
+        $path = '/some/path/to/file.txt';
+        $content = 'Test Content';
+        $expiry = date('Y-m-d H:i:s', strtotime('+2 day'));
+        $config = new Config([
+            'expiry' => $expiry,
+        ]);
+
+        $actual = $this->adapter
+            ->write($path, $content, $config);
+
+        $expected = [
+            'path_id' => $pathId,
+            'type' => 'file',
+            'path' => $path,
+            'timestamp' => time(),
+            'mimetype' => 'text/plain',
+            'size' => strlen($content),
+            'visibility' => 'public',
+            'expiry' => $expiry,
+        ];
+        static::assertSame($expected, $actual);
+    }
+
     public function testWriteWithDbFailure(): void
     {
         $this->setupBasicDbResponse(false);
@@ -257,6 +290,47 @@ class PdoAdapterTest extends TestCase
             ->update($path, $content, $this->emptyConfig);
 
         static::assertSame(strlen($content), $meta['size']);
+    }
+
+    public function testUpdateWithExpiry(): void
+    {
+        $pathId = rand(1, 1000);
+
+        $path = '/some/path/to/file.txt';
+        $content = 'Test Content';
+        $expiry = date('Y-m-d H:i:s', strtotime('+2 day'));
+        $config = new Config([
+            'expiry' => $expiry,
+        ]);
+
+        $data = [
+            'path_id' => $pathId,
+            'type' => 'file',
+            'path' => $path,
+            'mimetype' => 'text/plain',
+            'visibility' => 'public',
+            'size' => 214454,
+            'is_compressed' => false,
+            // no expiry set
+            'update_ts' => date('Y-m-d H:i:s'),
+        ];
+
+        $this->setupDbFetchResponse($data);
+
+        $actual = $this->adapter
+            ->update($path, $content, $config);
+
+        $expected = [
+            'path_id' => $pathId,
+            'type' => 'file',
+            'path' => $path,
+            'timestamp' => time(),
+            'mimetype' => 'text/plain',
+            'size' => strlen($content),
+            'visibility' => 'public',
+            'expiry' => $expiry,
+        ];
+        static::assertSame($expected, $actual);
     }
 
     public function testUpdateWithDbFailure(): void
@@ -641,6 +715,111 @@ class PdoAdapterTest extends TestCase
         static::assertFalse($this->adapter->has('/this/path'));
     }
 
+    public function testRead(): void
+    {
+        $pathId = rand(1, 1000);
+        $size = rand(1000, 99999);
+        $path = '/path/to/file.txt';
+        $updateTs = date('Y-m-d H:i:s');
+
+        $this->setupDbFetchResponse([
+            'path_id' => $pathId,
+            'path' => $path,
+            'type' => 'file',
+            'mimetype' => 'text/plain',
+            'visibility' => AdapterInterface::VISIBILITY_PRIVATE,
+            'size' => $size,
+            'is_compressed' => false,
+            'update_ts' => $updateTs,
+        ]);
+
+        $expected = [
+            'path_id' => $pathId,
+            'type' => 'file',
+            'path' => '/path/to/file.txt',
+            'timestamp' => strtotime($updateTs),
+            'mimetype' => 'text/plain',
+            'size' => $size,
+            'visibility' => AdapterInterface::VISIBILITY_PRIVATE,
+            'contents' => '',
+        ];
+
+        $actual = $this->adapter->read($path);
+        static::assertSame($expected, $actual);
+    }
+
+    public function testReadWithExpiryFuture(): void
+    {
+        $pathId = rand(1, 1000);
+        $size = rand(1000, 99999);
+        $path = '/path/to/file.txt';
+        $updateTs = date('Y-m-d H:i:s');
+        $expiry = date('Y-m-d H:i:s', strtotime('+2 day'));
+
+        $this->setupDbFetchResponse([
+            'path_id' => $pathId,
+            'path' => $path,
+            'type' => 'file',
+            'mimetype' => 'text/plain',
+            'visibility' => AdapterInterface::VISIBILITY_PRIVATE,
+            'size' => $size,
+            'is_compressed' => false,
+            'expiry' => $expiry,
+            'update_ts' => $updateTs,
+        ]);
+
+        $expected = [
+            'path_id' => $pathId,
+            'type' => 'file',
+            'path' => '/path/to/file.txt',
+            'timestamp' => strtotime($updateTs),
+            'mimetype' => 'text/plain',
+            'size' => $size,
+            'visibility' => AdapterInterface::VISIBILITY_PRIVATE,
+            'expiry' => $expiry,
+            'contents' => '',
+        ];
+
+        $actual = $this->adapter->read($path);
+        static::assertSame($expected, $actual);
+    }
+
+    public function testReadWithExpiryPast(): void
+    {
+        $pathId = rand(1, 1000);
+        $size = rand(1000, 99999);
+        $path = '/path/to/file.txt';
+        $updateTs = date('Y-m-d H:i:s');
+        $expiry = date('Y-m-d H:i:s', strtotime('-2 day'));
+
+        $this->setupDbFetchResponse([
+            'path_id' => $pathId,
+            'path' => $path,
+            'type' => 'file',
+            'mimetype' => 'text/plain',
+            'visibility' => AdapterInterface::VISIBILITY_PRIVATE,
+            'size' => $size,
+            'is_compressed' => false,
+            'expiry' => $expiry,
+            'update_ts' => $updateTs,
+        ]);
+
+        $expected = [
+            'path_id' => $pathId,
+            'type' => 'file',
+            'path' => '/path/to/file.txt',
+            'timestamp' => strtotime($updateTs),
+            'mimetype' => 'text/plain',
+            'size' => $size,
+            'visibility' => AdapterInterface::VISIBILITY_PRIVATE,
+            'expiry' => $expiry,
+            'contents' => '',
+        ];
+
+        $actual = $this->adapter->read($path);
+        static::assertFalse($actual);
+    }
+
     public function testReadReturnsContents(): void
     {
         $path = '/path/to/file.txt';
@@ -848,6 +1027,89 @@ class PdoAdapterTest extends TestCase
             [$rowData, 'timestamp', $timestamp],
             [$rowData, 'visibility', $visibility],
         ];
+    }
+
+    public function testDeleteExpiredDefault(): void
+    {
+        $pathId = rand(1, 1000);
+
+        $rows = [[
+            'path_id' => $pathId,
+        ]];
+
+        $selectSql = static::stringContains('WHERE expiry <= :now');
+        $expiredStmt = $this->createMock(\PDOStatement::class);
+
+        $deleteSql = static::logicalAnd(
+            static::stringContains('DELETE FROM '),
+            static::stringContains('WHERE path_id = :path_id'),
+        );
+        $deleteStmt = $this->createMock(\PDOStatement::class);
+
+        $this->pdo->expects(static::exactly(2))
+            ->method('prepare')
+            ->withConsecutive(
+                [$selectSql],
+                [$deleteSql],
+            )
+            ->willReturnOnConsecutiveCalls(
+                $expiredStmt,
+                $deleteStmt,
+            );
+
+        $expiredStmt->expects(static::once())
+            ->method('execute')
+            ->with([
+                'now' => date('Y-m-d H:i:s'),
+            ])
+            ->willReturn(true);
+
+        $expiredStmt->expects(static::once())
+            ->method('fetchAll')
+            ->willReturn($rows);
+
+        $expiredStmt->expects(static::once())
+            ->method('rowCount')
+            ->willReturn(1);
+
+        $deleteStmt->expects(static::once())
+            ->method('execute')
+            ->with([
+                'path_id' => $pathId,
+            ])
+            ->willReturn(true);
+
+        $this->adapter->deleteExpired();
+    }
+
+    public function testDeleteExpiredSpecific(): void
+    {
+        $expiry = date('Y-m-d H:i:s', strtotime('+2 day'));
+
+        $selectSql = static::stringContains('WHERE expiry <= :now');
+        $expiredStmt = $this->createMock(\PDOStatement::class);
+
+        $this->pdo->expects(static::once())
+            ->method('prepare')
+            ->with($selectSql)
+            ->willReturn($expiredStmt);
+
+        $expiredStmt->expects(static::once())
+            ->method('execute')
+            ->with([
+                'now' => $expiry,
+            ])
+            ->willReturn(true);
+
+        $expiredStmt->expects(static::once())
+            ->method('fetchAll')
+            ->willReturn([]);
+
+        $expiredStmt->expects(static::once())
+            ->method('rowCount')
+            ->willReturn(0);
+
+        $this->adapter->deleteExpired($expiry);
     }
 
     /**


### PR DESCRIPTION
- Started as just adding integration tests to add missing coverage for expiry, additional metadata, rename and getting standard metadata, but showed some issues in these areas to fix.
- Sample schemas now include the optional columns.
- Sample MySQL schema updates to avoid broken/deprecated `utf8` character set.
- Fix missing timestamp for Sqlite, and then correct the timezone when reading the value, as it always runs as UTC, which may be different to the local environment.
- Fix type error when using `deleteExpired()`
- Fix response behaviour when adding a file with additional metadata.
- Make `rename()` work with directory paths that don't exist as explicit records.