### PR TITLE
Set expiry date using \DateTimeImmutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Set optional expiry date using \DateTimeImmutable. Setting the expiry value as
+  a string is deprecated. Reading the file metadata will still return a string
+  for the expiry date, to avoid a BC break.
 
 ## [2.1.0] - 2022-09-01
 ### Added

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,9 +3,13 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
     bootstrap="vendor/autoload.php"
-    beStrictAboutOutputDuringTests="true"
     colors="true"
 >
+<!--
+@todo
+    beStrictAboutOutputDuringTests="true"
+    is omitted while deprecation notices are in place for expiry
+-->
     <php>
         <env name="INTEGRATION_ENABLED" value="0" />
         <env name="DB_DRIVER" value="mysql" />


### PR DESCRIPTION
- Using string value is deprecated, can be removed in the next major version.
- Next major version could change the meta return type to an object too.